### PR TITLE
Add support for pre-filling the message body

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ $mailto->setHeaders([
     'subject' => 'Hello World!',
     'cc'      => 'foo@example.com',
 ]);
+$mailto->setBody('Some message.');
 
 $mailto->getLink();
-# => mailto:test@example.com?subject=Hello+World!&cc=foo%40example.com
+# => mailto:test@example.com?subject=Hello%20World!&cc=foo%40example.com&body=Some%20message.
 ```
 
 ### Specifying multiple recipients
@@ -75,7 +76,7 @@ use SteveGrunwell\MailToLinkFormatter\MailTo;
 $mailto = new MailTo('test@example.com', [
     'subject' => 'Hello World!',
     'cc'      => 'foo@example.com',
-]);
+], 'This is the message body.');
 
 // This is equivalent to:
 $mailto = new MailTo;
@@ -84,6 +85,7 @@ $mailto->setHeaders([
     'subject' => 'Hello World!',
     'cc'      => 'foo@example.com',
 ]);
+$mailto->setBody('This is the message body.');
 ```
 
 ## License

--- a/src/MailTo.php
+++ b/src/MailTo.php
@@ -150,17 +150,23 @@ class MailTo
      */
     public function getLink(): string
     {
-        $headers = $this->getHeaders();
+        $parameters = $this->getHeaders();
+        $body = $this->getBody();
 
         // Flatten multi-dimensional arrays.
-        array_walk($headers, function (&$value, $header) {
+        array_walk($parameters, function (&$value, $header) {
             $value = implode(',', (array) $value);
         });
+
+        // Append the body, if we have one.
+        if ($body) {
+            $parameters['body'] = $body;
+        }
 
         $url = sprintf(
             'mailto:%s?%s',
             implode(',', $this->getRecipients()),
-            http_build_query($headers)
+            http_build_query($parameters, null, '&', PHP_QUERY_RFC3986)
         );
 
         // If the link ends in a question mark, strip it off.

--- a/src/MailTo.php
+++ b/src/MailTo.php
@@ -130,7 +130,7 @@ class MailTo
      */
     public function setBody(string $body)
     {
-        $this->body = $body;
+        $this->body = trim($body);
     }
 
     /**

--- a/tests/MailToTest.php
+++ b/tests/MailToTest.php
@@ -200,12 +200,26 @@ class MailToTest extends TestCase
 
     public function testSetBody()
     {
-        $this->markTestIncomplete('Body has not yet been implemented.');
+        $mailto = new MailTo;
+        $mailto->setBody('This is the message body.');
+
+        $this->assertEquals('This is the message body.', $this->getProperty($mailto, 'body'));
+    }
+
+    public function testSetBodyTrimsText()
+    {
+        $mailto = new MailTo;
+        $mailto->setBody('  This is the message body.' . PHP_EOL);
+
+        $this->assertEquals('This is the message body.', $this->getProperty($mailto, 'body'));
     }
 
     public function testGetBody()
     {
-        $this->markTestIncomplete('Body has not yet been implemented.');
+        $mailto = new MailTo;
+        $mailto->setBody('This is the message body');
+
+        $this->assertEquals('This is the message body', $mailto->getBody());
     }
 
     public function testGetLinkWithSingleRecipient()

--- a/tests/MailToTest.php
+++ b/tests/MailToTest.php
@@ -246,8 +246,26 @@ class MailToTest extends TestCase
         ]);
 
         $this->assertEquals(
-            'mailto:test@example.com?subject=My+Subject&cc=foo%40example.com',
+            'mailto:test@example.com?subject=My%20Subject&cc=foo%40example.com',
             $mailTo->getLink()
+        );
+    }
+
+    public function testGetLinkWithBody()
+    {
+        $body = <<<EOT
+Bacon ipsum dolor amet drumstick kevin biltong pork belly capicola leberkas ham. Porchetta beef short ribs filet mignon, spare ribs hamburger beef ribs cupim biltong shankle.
+
+Spare ribs beef porchetta, pastrami flank bresaola shoulder shank. Bacon salami pancetta jowl beef, shank shoulder boudin sausage swine landjaeger. Burgdoggen pancetta tri-tip shoulder pork belly beef ribs landjaeger shank cow beef cupim sausage salami leberkas.
+
+Fatback biltong shank burgdoggen pork loin pig pork chop ground round chicken pastrami.
+EOT;
+        $mailto = new MailTo('test@example.com');
+        $mailto->setBody($body);
+
+        $this->assertEquals(
+            'mailto:test@example.com?body=' . rawurlencode($body),
+            $mailto->getLink()
         );
     }
 


### PR DESCRIPTION
This PR adds support + documentation for setting the message body:

```php
$mailto = new MailTo('test@example.com);
$mailto->setBody('My message body.');

$mailTo->getLink();
# => mailto:test@example.com?body=My%20message%20body.
```

Fixes #1.