### PR TITLE
Magic setters and getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ If you're already including the Composer-generated autoloader in your project, t
 The `MailTo` class collects information about the `mailto:` link, then generates the link itself via its `getLink()` method:
 
 ```php
+use SteveGrunwell\MailToLinkFormatter\MailTo;
+
 $mailto = new MailTo;
 $mailto->setRecipients('test@example.com');
 $mailto->setHeaders([
@@ -31,11 +33,40 @@ $mailto->getLink();
 # => mailto:test@example.com?subject=Hello+World!&cc=foo%40example.com
 ```
 
+If you'd prefer, you may also set properties directly on the `MailTo` object, but be aware that this is merely a convenience method for the corresponding setters and getters:
+
+```php
+use SteveGrunwell\MailToLinkFormatter\MailTo;
+
+$mailto = new MailTo;
+
+// The same as calling $mailto->setRecipients('test@example.com').
+$mailto->recipients = 'test@example.com';
+
+// The same as calling $mailto->getRecipients().
+$mailto->recipients
+# => ['test@example.com']
+```
+
+Properties that are used that do not have corresponding setters/getters (e.g. anything except "recipients", "headers", and "body") will be treated as individual headers, passed through the `setHeader()` and `getHeader()` methods:
+
+```php
+use SteveGrunwell\MailToLinkFormatter\MailTo;
+
+$mailto = new MailTo;
+$mailto->subject = 'Message subject';
+
+$mailto->getHeaders();
+# => ['subject' => 'Message subject']
+```
+
 ### Specifying multiple recipients
 
 If the `mailto:` link should have multiple recipients, they can be set either by passing an array or a comma-separated string to `setRecipients()`:
 
 ```php
+use SteveGrunwell\MailToLinkFormatter\MailTo;
+
 $mailto = new MailTo;
 $mailto->setRecipients([
     'foo@example.com',

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
         "issues": "https://github.com/stevegrunwell/mailto-link-formatter/issues",
         "source": "https://github.com/stevegrunwell/mailto-link-formatter"
     },
-    "require": {},
+    "require": {
+        "php": ">=7.0"
+    },
     "require-dev": {
         "phpunit/phpunit": "^6.0"
     },

--- a/src/MailTo.php
+++ b/src/MailTo.php
@@ -47,6 +47,45 @@ class MailTo
     }
 
     /**
+     * Magic setter for methods.
+     *
+     * If a set{$property}() method exists, it will be called. Otherwise, the property will be
+     * treated as a new header.
+     *
+     * @param string $property The property being set.
+     * @param mixed  $value    The value being assigned to the property or header.
+     */
+    public function __set($property, $value)
+    {
+        $method = 'set' . ucwords($property);
+
+        if (method_exists($this, $method)) {
+            $this->$method($value);
+        } else {
+            $this->setHeader($property, $value);
+        }
+    }
+
+    /**
+     * Magic getter for methods.
+     *
+     * @param string $property The property being accessed.
+     *
+     * @return mixed Either the value of the property (if a get{$property}() method exists) or the
+     *               value of $this->getHeader($property), with a default of an empty string.
+     */
+    public function __get($property)
+    {
+        $method = 'get' . ucwords($property);
+
+        if (method_exists($this, $method)) {
+            return $this->$method();
+        } else {
+            return $this->getHeader($property, '');
+        }
+    }
+
+    /**
      * Set the message recipient(s).
      *
      * @param string|array $to One or more message recipients.

--- a/tests/MailToTest.php
+++ b/tests/MailToTest.php
@@ -13,6 +13,80 @@ use SteveGrunwell\MailToLinkFormatter\MailTo;
 
 class MailToTest extends TestCase
 {
+    public function testMagicSetterForRecipients()
+    {
+        $mailto = new MailTo;
+        $mailto->recipients = 'test@example.com';
+
+        $this->assertEquals([
+            'test@example.com',
+        ], $this->getProperty($mailto, 'recipients'));
+    }
+
+    public function testMagicSetterForHeaders()
+    {
+        $mailto = new MailTo;
+        $mailto->headers = [
+            'foo' => 'bar',
+        ];
+
+        $this->assertEquals([
+            'foo' => [
+                'bar'
+            ],
+        ], $this->getProperty($mailto, 'headers'));
+    }
+
+    public function testMagicSetterForBody()
+    {
+        $mailto = new MailTo;
+        $mailto->body = 'Message body';
+
+        $this->assertEquals('Message body', $this->getProperty($mailto, 'body'));
+    }
+
+    public function testMissingPropertiesAreCastAsHeaders()
+    {
+        $mailto = new MailTo;
+        $mailto->subject = 'My subject';
+
+        $this->assertEquals('My subject', $mailto->getHeader('subject'));
+    }
+
+    public function testMagicGetterForRecipients()
+    {
+        $mailto = new MailTo;
+        $mailto->recipients = 'test@example.com';
+
+        $this->assertEquals($mailto->getRecipients(), $mailto->recipients);
+    }
+
+    public function testMagicGetterForHeaders()
+    {
+        $mailto = new MailTo;
+        $mailto->headers = [
+            'foo' => 'bar',
+        ];
+
+        $this->assertEquals($mailto->getHeaders(), $mailto->headers);
+    }
+
+    public function testMagicGetterForBody()
+    {
+        $mailto = new MailTo;
+        $mailto->body = 'Message body';
+
+        $this->assertEquals($mailto->getBody(), $mailto->body);
+    }
+
+    public function testMissingPropertiesAreRetrievedAsHeaders()
+    {
+        $mailto = new MailTo;
+        $mailto->foo = uniqid();
+
+        $this->assertEquals($mailto->getHeader('foo'), $mailto->foo);
+    }
+
     public function testSetRecipients()
     {
         $mailto = new MailTo;


### PR DESCRIPTION
Enable developers to interact with `MailTo` properties as though they're public, but passing them through the setters and getters.

For example:

```php
$mailto = New MailTo;
$mailto->recipients = 'test@example.com';
$mailto->subject = 'My subject';

// This is the same as calling:
$mailto = new MailTo;
$mailto->setRecipients('test@example.com');
$mailto->setHeader('subject', 'My subject');
```

Fixes #2.